### PR TITLE
Correct spelling of Cocoapods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # [CKToolbox](http://itsthejb.github.io/CKToolbox/)
 
-A set of helpers and features for working with [Facebook ComponentKit](http://componentkit.org/). This library, when installed via [Cocoapods](https://cocoapods.org/), is modular. It currently has the following modules:
+A set of helpers and features for working with [Facebook ComponentKit](http://componentkit.org/). This library, when installed via [CocoaPods](https://cocoapods.org/), is modular. It currently has the following modules:
 
 1. [CKTableViewTransactionalDataSource](#CKTableViewTransactionalDataSource)
 2. [CKCollectionViewDataSourceChangesetBuilder](#CKCollectionViewDataSourceChangesetBuilder)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
